### PR TITLE
make default filterregex a raw string

### DIFF
--- a/check-systemd-service
+++ b/check-systemd-service
@@ -413,7 +413,7 @@ def main():
                       help='increase output verbosity (use up to 3 times)')
     argp.add_argument('-t', '--timeout', default=10,
                       help='abort execution after TIMEOUT seconds')
-    argp.add_argument('-f', '--filter', default='^.*\.service$',
+    argp.add_argument('-f', '--filter', default=r'^.*.service$',
                       help='regexp for filtering systemd units')
     args = argp.parse_args()
     if len(args.units) == 1:


### PR DESCRIPTION
Unrecognized escape sequences produce a DeprecationWarning in python 3.6 and a SyntaxError in python 3.12.
I just use a raw strings so the test works on Python 3.13